### PR TITLE
Needs GHC >= 7.6 due to MultiWayIf

### DIFF
--- a/redis-resp.cabal
+++ b/redis-resp.cabal
@@ -38,7 +38,7 @@ library
 
     build-depends:
         attoparsec            >= 0.11   && < 1.0
-      , base                  >= 4.5    && < 5.0
+      , base                  >= 4.6    && < 5.0
       , bytestring            >= 0.10.4 && < 1.0
       , bytestring-conversion >= 0.2    && < 1.0
       , containers            >= 0.5    && < 1.0


### PR DESCRIPTION
I've revised current versions (https://hackage.haskell.org/package/redis-resp/revisions/) so a new release isn't necessary.
